### PR TITLE
fix: waitlist email sender and signup label

### DIFF
--- a/src/components/auth/signupForm.tsx
+++ b/src/components/auth/signupForm.tsx
@@ -95,7 +95,7 @@ export function SignupForm({
               render={({ field }) => (
                 <FormItem>
                   <FormLabel className="dark:text-gray-200 text-gray-800">
-                    Password
+                    Confirm Password
                   </FormLabel>
                   <FormControl>
                     <Input placeholder="••••••••" {...field} type="password" />

--- a/src/lib/mails/waitlist.ts
+++ b/src/lib/mails/waitlist.ts
@@ -3,7 +3,7 @@ import { sendMail } from "$lib/mailer";
 
 export const sendWaitlistMail = async (email: string) => {
   const mailOptions: MailOptions = {
-    from: 'Sifter "<noreply@sifter-app.com>"',
+    from: 'Sifter <noreply@sifter-app.com>',
     to: email,
     subject: "Welcome to Sifter Waitlist",
     html: waitlistHTML,


### PR DESCRIPTION
## Summary
- fix the `from` address in the waitlist email helper
- correct the confirm password label on the signup form

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d91708b54832abc223a01a3ca2210