### PR TITLE
Fix OAuth buttons to avoid form submission

### DIFF
--- a/src/components/auth/loginForm.tsx
+++ b/src/components/auth/loginForm.tsx
@@ -113,7 +113,7 @@ export function LoginForm({
       <div className="flex flex-col space-y-4">
         <button
           className=" relative group/btn flex space-x-2 items-center justify-start px-4 w-full text-black rounded-md h-10 font-medium shadow-input bg-gray-50 dark:bg-zinc-900 dark:shadow-[0px_0px_1px_1px_var(--neutral-800)]"
-          type="submit"
+          type="button"
           onClick={() => toast({ description: "Not available during beta" })}
         >
           <IconBrandGithub className="h-4 w-4 text-neutral-800 dark:text-neutral-300" />
@@ -124,7 +124,7 @@ export function LoginForm({
         </button>
         <button
           className=" relative group/btn flex space-x-2 items-center justify-start px-4 w-full text-black rounded-md h-10 font-medium shadow-input bg-gray-50 dark:bg-zinc-900 dark:shadow-[0px_0px_1px_1px_var(--neutral-800)]"
-          type="submit"
+          type="button"
           onClick={() => toast({ description: "Not available during beta" })}
         >
           <IconBrandGoogle className="h-4 w-4 text-neutral-800 dark:text-neutral-300" />

--- a/src/components/auth/signupForm.tsx
+++ b/src/components/auth/signupForm.tsx
@@ -130,7 +130,7 @@ export function SignupForm({
       <div className="flex flex-col space-y-4">
         <button
           className=" relative group/btn flex space-x-2 items-center justify-start px-4 w-full text-black rounded-md h-10 font-medium shadow-input bg-gray-50 dark:bg-zinc-900 dark:shadow-[0px_0px_1px_1px_var(--neutral-800)]"
-          type="submit"
+          type="button"
           onClick={() => {
             toast({ description: "Not available during beta" });
           }}
@@ -143,7 +143,7 @@ export function SignupForm({
         </button>
         <button
           className=" relative group/btn flex space-x-2 items-center justify-start px-4 w-full text-black rounded-md h-10 font-medium shadow-input bg-gray-50 dark:bg-zinc-900 dark:shadow-[0px_0px_1px_1px_var(--neutral-800)]"
-          type="submit"
+          type="button"
           onClick={() => {
             toast({ description: "Not available during beta" });
           }}


### PR DESCRIPTION
## Summary
- fix GitHub/Google OAuth buttons so they use `type="button"`

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_685f1457e3d0832aa612c1beabac713d